### PR TITLE
Feature - deleting bloat files

### DIFF
--- a/include/url.h
+++ b/include/url.h
@@ -19,6 +19,9 @@ std::string yezzey_block_file_path(const std::string &nspname,
                                    relnodeCoord coords, int32_t segid);
 
 std::string yezzey_block_namespace_path(int32_t segid);
+std::string yezzey_block_db_file_path(const std::string &nspname,
+                                   const std::string &relname,
+                                   relnodeCoord coords, int32_t segid);
 
 /* un-prefixed version of `craftStoragePrefixedPath` */
 std::string craftStorageUnPrefixedPath(const std::shared_ptr<IOadv> &adv,

--- a/include/xvacuum.h
+++ b/include/xvacuum.h
@@ -14,5 +14,6 @@
 EXTERNC int yezzey_delete_chunk_internal(const char *external_chunk_path);
 EXTERNC int yezzey_vacuum_garbage_internal(int segindx, bool confirm,
                                            bool crazyDrop);
-
+EXTERNC int yezzey_vacuum_garbage_relation_internal(Oid reloid, int segindx, bool confirm,
+                                           bool crazyDrop);
 #endif /* YEZZEY_XVACUUM_H */

--- a/src/url.cpp
+++ b/src/url.cpp
@@ -53,7 +53,16 @@ std::string yezzey_block_file_path(const std::string &nspname,
 
   return url;
 }
+std::string yezzey_block_db_file_path(const std::string &nspname,
+                                   const std::string &relname,
+                                   relnodeCoord coords, int32_t segid){
+  std::string url = yezzey_block_namespace_path(segid);
+  url += std::to_string(coords.spcNode) + "_" + std::to_string(coords.dboid) + "_";
 
+  auto md = yezzey_fqrelname_md5(nspname, relname);
+  url += md;
+  return url;
+}
 /* prefix-independent WAL-G compatable path */
 std::string craftStorageUnPrefixedPath(const std::shared_ptr<IOadv> &adv,
                                        ssize_t segindx, ssize_t modcount,

--- a/src/xvacuum.cpp
+++ b/src/xvacuum.cpp
@@ -79,3 +79,51 @@ int yezzey_vacuum_garbage_internal(int segindx, bool confirm, bool crazyDrop) {
   }
   return 0;
 }
+int yezzey_vacuum_garbage_relation_internal(Relation rel,int segindx, bool confirm,bool crazyDrop){
+  try {
+    auto ioadv = std::make_shared<IOadv>(
+        std::string(gpg_engine_path), std::string(gpg_key_id),
+        std::string(storage_config), "", "", std::string(storage_host /*host*/),
+        std::string(storage_bucket /*bucket*/),
+        std::string(storage_prefix /*prefix*/),
+        std::string(storage_class /*storage_class*/), multipart_chunksize,
+        DEFAULTTABLESPACE_OID, "" /* coords */, InvalidOid /* reloid */,
+        std::string(walg_bin_path), std::string(walg_config_path),
+        use_gpg_crypto, yproxy_socket);
+
+    auto tp = SearchSysCache1(NAMESPACEOID,
+                              ObjectIdGetDatum(RelationGetNamespace(rel)));
+
+    if (!HeapTupleIsValid(tp)) {
+      elog(ERROR, "yezzey: failed to get namescape name of relation %d",
+           RelationGetNamespace(rel));
+    }
+    
+    relnodeCoord coords{1663,rel->rd_node.dbNode,rel->rd_node.relNode,segindx};
+    Form_pg_namespace nsptup = (Form_pg_namespace)GETSTRUCT(tp);
+    auto nspname = std::string(nsptup->nspname.data);
+    std::string relname = RelationGetRelationName(rel);
+
+    std::string storage_path(yezzey_block_db_file_path(nspname,relname,coords,segindx));
+
+    auto deleter =
+        std::make_shared<YProxyDeleter>(ioadv, ssize_t(segindx), confirm);
+    ReleaseSysCache(tp);
+
+    if (deleter->deleteChunk(storage_path)) {
+      return 0;
+    }
+
+    return -1;
+  } catch (...) {
+    elog(ERROR, "failed to prepare x-storage reader for chunk");
+    return 0;
+  }
+  return 0;
+}
+int yezzey_vacuum_garbage_relation_internal(Oid reloid,int segindx, bool confirm, bool crazyDrop) {
+    Relation rel = relation_open(reloid,NoLock);
+    int rc = yezzey_vacuum_garbage_relation_internal(rel,segindx,confirm,crazyDrop);
+    relation_close(rel,NoLock);
+    return rc;
+}

--- a/worker.c
+++ b/worker.c
@@ -477,12 +477,17 @@ yezzey_ProcessUtility_hook(Node *parsetree,
 #if IsGreenplum6
 			{
 				VacuumStmt *stmt = (VacuumStmt *) parsetree;
-        if (stmt->options & VACOPT_YEZZEY) {
+        if(!stmt->relation){
+          break;
+        }
+        Relation rel = relation_openrv(stmt->relation,NoLock);
+        if (stmt->options & VACOPT_YEZZEY & (rel->rd_node.spcNode == YEZZEYTABLESPACE_OID)) {
           if (Gp_role == GP_ROLE_EXECUTE) {
             Assert(GpIdentity.segindex != -1);
-            yezzey_vacuum_garbage_internal(GpIdentity.segindex, true, false);
+            yezzey_vacuum_garbage_relation_internal(rel, GpIdentity.segindex,true,false);
           }
         }
+        relation_close(rel,NoLock);
 			}
 #endif
 			break;

--- a/yezzey--1.8--1.8.1.sql
+++ b/yezzey--1.8--1.8.1.sql
@@ -7,3 +7,53 @@ AS 'MODULE_PATHNAME'
 VOLATILE
 EXECUTE ON ALL SEGMENTS
 LANGUAGE C STRICT;
+
+CREATE OR REPLACE FUNCTION yezzey_vacuum_relation(
+    reloid OID,
+    confirm BOOLEAN DEFAULT FALSE,
+    crazyDrop BOOLEAN DEFAULT FALSE
+) RETURNS void
+AS 'MODULE_PATHNAME'
+VOLATILE
+EXECUTE ON ALL SEGMENTS
+LANGUAGE C STRICT;
+
+
+CREATE OR REPLACE FUNCTION yezzey_vacuum_garbage_relation(
+    i_offload_nspname TEXT,
+    i_offload_relname TEXT,
+    confirm BOOLEAN DEFAULT FALSE,
+    crazyDrop BOOLEAN DEFAULT FALSE
+) RETURNS void
+AS $$
+DECLARE
+    v_reloid OID;
+BEGIN
+    SELECT 
+        oid
+    FROM 
+        pg_catalog.pg_class
+    INTO v_reloid 
+    WHERE 
+        relname = i_offload_relname AND relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = i_offload_nspname);
+
+    PERFORM yezzey_vacuum_relation(
+        v_reloid,confirm,crazyDrop
+    );
+END;
+$$
+LANGUAGE PLPGSQL;
+
+
+CREATE OR REPLACE FUNCTION
+yezzey_vacuum_garbage_relation(
+    i_offload_relname TEXT,
+    confirm BOOLEAN DEFAULT FALSE,
+    crazyDrop BOOLEAN DEFAULT FALSE)
+RETURNS VOID
+AS $$
+BEGIN
+    PERFORM yezzey_vacuum_garbage_relation('public', i_offload_relname, confirm, crazyDrop);
+END;
+$$
+LANGUAGE PLPGSQL;

--- a/yezzey.c
+++ b/yezzey.c
@@ -114,6 +114,7 @@ PG_FUNCTION_INFO_V1(yezzey_check_part_exr);
 
 PG_FUNCTION_INFO_V1(yezzey_delete_chunk);
 PG_FUNCTION_INFO_V1(yezzey_vacuum_garbage);
+PG_FUNCTION_INFO_V1(yezzey_vacuum_relation);
 
 
 /* Create yezzey metadata tables */
@@ -131,7 +132,7 @@ int yezzey_offload_relation_internal(Oid reloid, bool remove_locally,
 
 int yezzey_delete_chunk_internal(const char *external_chunk_path);
 int yezzey_vacuum_garbage_internal(int segindx, bool confirm, bool crazyDrop);
-
+int yezzey_vacuum_garbage_relation_internal(Oid reloid,int segindx, bool confirm, bool crazyDrop);
 /*
  * yezzey_define_relation_offload_policy_internal:
  * do all the work with initial relation offloading
@@ -438,6 +439,26 @@ Datum yezzey_vacuum_garbage(PG_FUNCTION_ARGS) {
   PG_RETURN_VOID();
 }
 
+Datum yezzey_vacuum_relation(PG_FUNCTION_ARGS) {
+  Oid reloid = PG_GETARG_OID(0);
+  bool confirm;
+  bool crazyDrop;
+  int rc;
+  confirm = PG_GETARG_BOOL(1);
+  crazyDrop = PG_GETARG_BOOL(2);
+  if (GpIdentity.segindex == -1) {
+    elog(ERROR, "yezzey_vacuum_garbage_internal should be executed on SEGMENT");
+  }
+
+  if (crazyDrop && !superuser()) {
+    elog(ERROR, "crazyDrop forbidden for non-superuser");
+  }
+
+  rc = yezzey_vacuum_garbage_relation_internal(reloid,GpIdentity.segindex,confirm,crazyDrop);
+
+  PG_RETURN_VOID();
+
+}
 Datum yezzey_show_relation_external_path(PG_FUNCTION_ARGS) {
   Oid reloid;
   Relation aorel;


### PR DESCRIPTION
New sql func yezzey_vacuum_garbage_relation('<table_name>',bool confirm,bool crazyDrop);
- Removes bloat files by table name

New internal c funcs
- yezzey_vacuum_garbage_relation_internal(Re rel / OId reloid, int segindx, bool confirm, bool crazyDrop)
- - Deletes bloat files from a table by relation or oid

Slightly rewritten vacuum hook (does not worked correct) ((does not work))

https://github.com/open-gpdb/yproxy/pull/72