### PR TITLE
resolve temp table name to original

### DIFF
--- a/include/pg.h
+++ b/include/pg.h
@@ -39,6 +39,7 @@ extern "C" {
 #include "storage/smgr.h"
 #include "utils/catcache.h"
 #include "utils/syscache.h"
+#include "utils/lsyscache.h"
 
 #include "catalog/dependency.h"
 #include "catalog/pg_extension.h"
@@ -99,6 +100,7 @@ extern "C" {
 #include "catalog/pg_namespace.h"
 #include "utils/catcache.h"
 #include "utils/syscache.h"
+#include "utils/lsyscache.h"
 
 #include "catalog/heap.h"
 

--- a/include/util.h
+++ b/include/util.h
@@ -43,6 +43,8 @@ std::string make_yezzey_url(const std::string &prefix, int64_t modcounts,
 
 std::vector<int64_t> parseModcounts(const std::string &prefix,
                                     std::string name);
+
+std::string resolve_temp_relname(char *tempname);
 #endif
 
 EXTERNC void getYezzeyExternalStoragePathByCoords(

--- a/src/proxy.cpp
+++ b/src/proxy.cpp
@@ -207,7 +207,7 @@ EXTERNC SMGRFile yezzey_AORelOpenSegFile(Oid reloid, char *nspname,
            */
           Assert(RecoveryInProgress());
         } else {
-          yfd.relname = std::string(relname);
+          yfd.relname = resolve_temp_relname(relname);
           yfd.nspname = std::string(nspname);
         }
       } else {

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -185,3 +185,13 @@ XLogRecPtr yezzeyGetXStorageInsertLsn(void) {
 
   return GetXLogWriteRecPtr();
 }
+
+std::string resolve_temp_relname(char* tempname) {
+  std::string name(tempname);
+  if (strncmp(name.c_str(), "pg_temp_", 8) == 0)
+  {
+    int oid = atoi(name.substr(8, name.find('_', 8)).c_str());
+    return std::string(get_rel_name(oid));
+  }
+  return tempname;
+}


### PR DESCRIPTION
REORGANIZE is done via temporary table with name `pg_temp_<relid>_*`. That is why we get wrong hash for external path. I propose replacing it with original name