### PR TITLE
Fix ALTER TABLE .. DROP corruption

### DIFF
--- a/yezzey.c
+++ b/yezzey.c
@@ -1197,7 +1197,7 @@ void yezzey_object_access_hook (ObjectAccessType access,
   }
 
 
-  if (access == OAT_DROP) {
+  if (access == OAT_DROP && subId == 0) {
     (void)emptyYezzeyIndex(YezzeyFindAuxIndex(RelationGetRelid(offRel)), offRel->rd_node.relNode);
     (void)FixupOffloadMetadata(RelationGetRelid(offRel));
   } else if (access == OAT_POST_ALTER) { 


### PR DESCRIPTION
Cleanup yezzey metadata relations only
on base relation drop. Thus, check for subid