### PR TITLE
Yezzey: fix truncate metadata bug

### DIFF
--- a/expected/yezzey-trunc.out
+++ b/expected/yezzey-trunc.out
@@ -74,6 +74,12 @@ SELECT count(1) FROM trunc_regaoty;
 (1 row)
 
 TRUNCATE trunc_regaoty;
+SELECT count(1) from yezzey_dump_virtual_index('trunc_regaoty');
+ count 
+-------
+     0
+(1 row)
+
 SELECT count(1) FROM trunc_regaoty;
  count 
 -------
@@ -183,6 +189,12 @@ SELECT count(1) FROM trunc_regaocsty;
 (1 row)
 
 TRUNCATE trunc_regaocsty;
+SELECT count(1) from yezzey_dump_virtual_index('trunc_regaoty');
+ count 
+-------
+     0
+(1 row)
+
 SELECT count(1) FROM trunc_regaocsty;
  count 
 -------

--- a/smgr.c
+++ b/smgr.c
@@ -155,6 +155,7 @@ void yezzey_unlink(RelFileNodeBackend rnode, ForkNumber forkNum, bool isRedo,
 #else
   if (rnode.node.spcNode == YEZZEYTABLESPACE_OID) {
     /*do nothing */
+    
     return;
   }
 

--- a/sql/yezzey-trunc.sql
+++ b/sql/yezzey-trunc.sql
@@ -27,6 +27,7 @@ INSERT INTO trunc_regaoty SELECT * FROM generate_series(1, 100000);
 SELECT count(1) FROM trunc_regaoty;
 
 TRUNCATE trunc_regaoty;
+SELECT count(1) from yezzey_dump_virtual_index('trunc_regaoty');
 SELECT count(1) FROM trunc_regaoty;
 
 SELECT count() FROM yezzey_offload_relation_status('trunc_regaoty');
@@ -67,6 +68,7 @@ INSERT INTO trunc_regaocsty SELECT * FROM generate_series(1, 100000);
 SELECT count(1) FROM trunc_regaocsty;
 
 TRUNCATE trunc_regaocsty;
+SELECT count(1) from yezzey_dump_virtual_index('trunc_regaoty');
 SELECT count(1) FROM trunc_regaocsty;
 
 SELECT count() FROM yezzey_offload_relation_status('trunc_regaocsty');

--- a/src/virtual_tablespace.cpp
+++ b/src/virtual_tablespace.cpp
@@ -68,13 +68,14 @@ void YezzeyATExecSetTableSpace(Relation aorel, Oid reloid,
    */
 
   /* drop old relation, and close new one */
-  RelationDropStorage(aorel);
+  if (desttablespace_oid == YEZZEYTABLESPACE_OID)
+    RelationDropStorage(aorel);
 
   /* update the pg_class row */
-  if (desttablespace_oid != YEZZEYTABLESPACE_OID) {
+  if (desttablespace_oid != YEZZEYTABLESPACE_OID)
     rd_rel->relfilenode = GetNewRelFileNode(desttablespace_oid, NULL,
                                             aorel->rd_rel->relpersistence);
-  }
+
   rd_rel->reltablespace = desttablespace_oid;
 
 #if IsGreenplum6

--- a/yezzey.c
+++ b/yezzey.c
@@ -1320,6 +1320,12 @@ static void yezzey_define_gucs() {
                           PGC_SUSET, 0, NULL, NULL, NULL);
 }
 
+void yezzey_TrackObjDrop (Relation rel)
+{
+  if (rel->rd_node.spcNode == YEZZEYTABLESPACE_OID)
+    (void)emptyYezzeyIndex(YezzeyFindAuxIndex(RelationGetRelid(rel)), rel->rd_node.relNode);
+}
+
 void _PG_init(void) {
   /* Allocate shared memory for yezzey workers */
 
@@ -1340,4 +1346,6 @@ void _PG_init(void) {
 
   ExecutorStart_hook = yezzey_ExecuterStartHook;
   ExecutorEnd_hook = yezzey_ExecuterEndHook;
+
+  TrackDropObject_hook = yezzey_TrackObjDrop;
 }

--- a/yezzey.c
+++ b/yezzey.c
@@ -333,7 +333,7 @@ int yezzey_load_relation_internal(Oid reloid, const char *dest_path) {
   * Do not empty, just drop
   * Dropping yezzey virtual index for loaded relation allow to
   * remove extension dependecy on this object (relation)
-  * empty all track info **
+  * empty all track info
   */
  
   (void)emptyYezzeyIndex(yandexoid, origrelfilenode);


### PR DESCRIPTION
Cleanup yezzey_virtual_index on relation TRUNCATE via hook.