### PR TITLE
Fix offload_metadata_indx corruption.

### DIFF
--- a/src/offload_policy.cpp
+++ b/src/offload_policy.cpp
@@ -238,12 +238,22 @@ bool YezzeySetRelationExpiritySeg(Oid i_reloid, int i_relpolicy,
     auto offtuple = heap_form_tuple(RelationGetDescr(offrel), values, nulls);
 
     simple_heap_update(offrel, &oldtuple->t_self, offtuple);
+#if IsGreenplum6
+    CatalogUpdateIndexes(offrel, offtuple);
+#else
+    CatalogTupleUpdate(offrel, &oldtuple->t_self, offtuple);
+#endif
 
     heap_freetuple(offtuple);
   } else {
     auto offtuple = heap_form_tuple(RelationGetDescr(offrel), values, nulls);
 
     simple_heap_insert(offrel, offtuple);
+#if IsGreenplum6
+    CatalogUpdateIndexes(offrel, offtuple);
+#else
+    CatalogTupleUpdate(offrel, &oldtuple->t_self, offtuple);
+#endif
 
     heap_freetuple(offtuple);
   }
@@ -393,7 +403,12 @@ void YezzeyLoadRelation(Oid i_reloid) {
 
     auto offtuple = heap_form_tuple(RelationGetDescr(rel), values, nulls);
 
+#if IsGreenplum6
     simple_heap_update(rel, &oldtuple->t_self, offtuple);
+    CatalogUpdateIndexes(rel, offtuple);
+#else
+    CatalogTupleUpdate(rel, &oldtuple->t_self, offtuple);
+#endif
 
     heap_freetuple(offtuple);
   } else {

--- a/src/offload_tablespace_map.cpp
+++ b/src/offload_tablespace_map.cpp
@@ -192,6 +192,12 @@ void YezzeyRegisterRelationOriginTablespaceName(Oid i_reloid, Name i_spcname) {
                                    values, nulls);
 
   simple_heap_insert(offload_tablespace_map_rel, nofftuple);
+#if IsGreenplum6
+    CatalogUpdateIndexes(offload_tablespace_map_rel, nofftuple);
+#else
+	CatalogTupleInsert(offload_tablespace_map_rel, nofftuple);
+#endif
+
   heap_close(offload_tablespace_map_rel, RowExclusiveLock);
 
   heap_freetuple(nofftuple);


### PR DESCRIPTION
Never forget to update catalog indixies. Testing this change without heapallindexed is a bit of a challendge, so wait for proper amcheck support in core.