### PR TITLE
Fix alter table reorganize with non-default tablespaces

### DIFF
--- a/expected/yezzey-otm-feat.out
+++ b/expected/yezzey-otm-feat.out
@@ -240,6 +240,11 @@ SELECT spcname from pg_tablespace where oid = (select reltablespace from pg_clas
  tab2
 (1 row)
 
+-- test simple reorgnaze & vacuum 
+ALTER TABLE yezzey_otm_regaoty_1 SET WITH (reorganize=TRUE);
+VACUUM FULL yezzey_otm_regaoty_1;
+ALTER TABLE yezzey_otm_regaoty_2 SET WITH (reorganize=TRUE);
+VACUUM FULL yezzey_otm_regaoty_2;
 DROP TABLE yezzey_otm_regaoty_1;
 DROP TABLE yezzey_otm_regaoty_2;
 DROP TABLESPACE tab1;

--- a/sql/yezzey-otm-feat.sql
+++ b/sql/yezzey-otm-feat.sql
@@ -25,10 +25,8 @@ INSERT INTO yezzey_otm_regaoty_1 VALUES (1111, repeat('a', 2323323));
 CREATE TABLE yezzey_otm_regaoty_2(i INT, s TEXT) WITH (appendonly=true) TABLESPACE tab2;
 INSERT INTO yezzey_otm_regaoty_2 SELECT i, 'dssd' FROM generate_series(1, 100000) i;
 
-
 ALTER TABLE yezzey_otm_regaoty_2 ALTER COLUMN s SET STORAGE EXTERNAL;
 INSERT INTO yezzey_otm_regaoty_2 VALUES (1111, repeat('a', 2323323));
-
 
 SELECT * FROM yezzey_define_offload_policy('yezzey_otm_regaoty_1');
 
@@ -89,6 +87,13 @@ SELECT spcname from pg_tablespace where oid = (select reltablespace from pg_clas
 SELECT yezzey_load_relation('yezzey_otm_regaoty_2');
 
 SELECT spcname from pg_tablespace where oid = (select reltablespace from pg_class where relname='yezzey_otm_regaoty_2');
+
+-- test simple reorgnaze & vacuum 
+ALTER TABLE yezzey_otm_regaoty_1 SET WITH (reorganize=TRUE);
+VACUUM FULL yezzey_otm_regaoty_1;
+
+ALTER TABLE yezzey_otm_regaoty_2 SET WITH (reorganize=TRUE);
+VACUUM FULL yezzey_otm_regaoty_2;
 
 DROP TABLE yezzey_otm_regaoty_1;
 DROP TABLE yezzey_otm_regaoty_2;

--- a/src/offload_tablespace_map.cpp
+++ b/src/offload_tablespace_map.cpp
@@ -37,8 +37,8 @@ static Oid YezzeyResolveTablespaceMapOid() {
   ScanKeyInit(&skey[1], Anum_pg_class_relnamespace, BTEqualStrategyNumber,
               F_OIDEQ, ObjectIdGetDatum(YEZZEY_AUX_NAMESPACE));
 
-  auto scan =
-      yezzey_systable_beginscan(classrel, ClassNameNspIndexId, true, snap, 2, skey);
+  auto scan = yezzey_systable_beginscan(classrel, ClassNameNspIndexId, true,
+                                        snap, 2, skey);
 
   auto oldtuple = yezzey_systable_getnext(scan);
 
@@ -50,9 +50,8 @@ static Oid YezzeyResolveTablespaceMapOid() {
     return InvalidOid;
   }
 
-
 #if PG_VERSION_NUM >= 120000
-  Oid yezzey_tablespace_map_oid = ((Form_pg_class) GETSTRUCT(oldtuple))->oid;
+  Oid yezzey_tablespace_map_oid = ((Form_pg_class)GETSTRUCT(oldtuple))->oid;
 #else
   Oid yezzey_tablespace_map_oid = HeapTupleGetOid(oldtuple);
 #endif
@@ -125,7 +124,8 @@ std::string YezzeyGetRelationOriginTablespace(const char *nspname,
       return "pg_default";
     }
 
-    elog(ERROR, "failed to map relation %d to its origin tablespace", i_reloid);
+    elog(ERROR, "failed to map relation %d (%s.%s) to its origin tablespace",
+         i_reloid, nspname, relname);
   }
 
   auto rv = ((Form_offload_tablespace_map)GETSTRUCT(offtuple))
@@ -193,9 +193,9 @@ void YezzeyRegisterRelationOriginTablespaceName(Oid i_reloid, Name i_spcname) {
 
   simple_heap_insert(offload_tablespace_map_rel, nofftuple);
 #if IsGreenplum6
-    CatalogUpdateIndexes(offload_tablespace_map_rel, nofftuple);
+  CatalogUpdateIndexes(offload_tablespace_map_rel, nofftuple);
 #else
-	CatalogTupleInsert(offload_tablespace_map_rel, nofftuple);
+  CatalogTupleInsert(offload_tablespace_map_rel, nofftuple);
 #endif
 
   heap_close(offload_tablespace_map_rel, RowExclusiveLock);
@@ -217,7 +217,8 @@ void YezzeyRegisterRelationOriginTablespace(Oid i_reloid, Oid i_reltablespace) {
   if (!use_otm_feature && i_reltablespace != DEFAULTTABLESPACE_OID)
     ereport(ERROR,
             (errcode(ERRCODE_UNDEFINED_OBJECT),
-             errmsg("tablespace with OID %u is non-default, offload rejrected", i_reltablespace),
+             errmsg("tablespace with OID %u is non-default, offload rejrected",
+                    i_reltablespace),
              errdetail("turn yezzey.use_otm_feature GUC on")));
 
   auto spcname = &((Form_pg_tablespace)GETSTRUCT(spctuple))->spcname;
@@ -233,7 +234,15 @@ void YezzeyCopyOTM(const RangeVar *rv, Oid sourceRelationOid) {
 
   auto key = y_stringify_rv(rv->schemaname, rv->relname);
 
+  auto r = relation_open(sourceRelationOid, NoLock);
+
+  auto key_origin = y_stringify_rv(get_namespace_name(r->rd_rel->relnamespace),
+                                   RelationGetRelationName(r));
+  yezzey_otm_hint[key_origin] = val;
+
   yezzey_otm_hint[key] = val;
+
+  relation_close(r, NoLock);
 }
 
 void YezzeyTruncateOTMHint(void) { yezzey_otm_hint.clear(); }

--- a/yezzey.c
+++ b/yezzey.c
@@ -241,7 +241,7 @@ int yezzey_load_relation_internal(Oid reloid, const char *dest_path) {
     elog(ERROR, "attempted to load non-offloaded relation");
   }
 
-  Oid loadSpcOid = YezzeyGetRelationOriginTablespaceOid(NULL, NULL, RelationGetRelid(aorel));
+  Oid loadSpcOid = YezzeyGetRelationOriginTablespaceOid(get_namespace_name(aorel->rd_rel->relnamespace), RelationGetRelationName(aorel), RelationGetRelid(aorel));
 
   /* Perform actual deletion of yezzey virtual index and metadata changes */
   (void)YezzeyATExecSetTableSpace(aorel, reloid, loadSpcOid);
@@ -1294,7 +1294,7 @@ yezzey_ProcessUtility_hook(Node *parsetree,
         if (rel->rd_node.spcNode == YEZZEYTABLESPACE_OID) {
           foreach(lcmd, stmt->cmds)
           {
-            newTOASTTableSpace = YezzeyGetRelationOriginTablespaceOid(NULL, NULL, RelationGetRelid(rel));
+            newTOASTTableSpace = YezzeyGetRelationOriginTablespaceOid(get_namespace_name(rel->rd_rel->relnamespace), RelationGetRelationName(rel), RelationGetRelid(rel));
           }
         }
 


### PR DESCRIPTION
For offload tablespace map, postgresql
creates "temp" relation for reorganized
data. For yezzey, we need to know how
tablespace maps to external bucket, which is OTM entry used for. Make sure that "old" and "new" relation refers the same tablespace/buckets by simple in-memory hack. This is actaully worked before, but was fooled at some point, so add regression test for ALTER+OTM.