### PR TITLE
Report external bloat bytes in all stat functions starting 1.8.7

### DIFF
--- a/expected/yezzey-stat.out
+++ b/expected/yezzey-stat.out
@@ -70,7 +70,7 @@ ALTER EXTENSION yezzey UPDATE TO '1.8.7';
 SELECT sum(local_bytes), sum(external_bytes), sum(external_bloat_bytes) FROM yezzey_offload_relation_status('regaostat');
    sum   | sum |   sum   
 ---------+-----+---------
- 1001640 |   0 | 3004920
+ 1001640 |   0 | 6009840
 (1 row)
 
 SELECT * FROM yezzey_define_offload_policy('regaostat');
@@ -82,7 +82,7 @@ SELECT * FROM yezzey_define_offload_policy('regaostat');
 SELECT sum(local_bytes), sum(external_bytes), sum(external_bloat_bytes) FROM yezzey_offload_relation_status('regaostat');
  sum |   sum   |   sum   
 -----+---------+---------
-   0 | 1001640 | 3004920
+   0 | 1001640 | 7011480
 (1 row)
 
 DROP TABLE regaostat;

--- a/expected/yezzey-stat.out
+++ b/expected/yezzey-stat.out
@@ -68,9 +68,21 @@ SELECT sum(local_bytes), sum(external_bytes) FROM yezzey_offload_relation_status
 
 ALTER EXTENSION yezzey UPDATE TO '1.8.7';
 SELECT sum(local_bytes), sum(external_bytes), sum(external_bloat_bytes) FROM yezzey_offload_relation_status('regaostat');
-   sum   |   sum   |   sum   
----------+---------+---------
- 1001640 | 6009840 | 6009840
+   sum   | sum |   sum   
+---------+-----+---------
+ 1001640 |   0 | 3004920
+(1 row)
+
+SELECT * FROM yezzey_define_offload_policy('regaostat');
+ yezzey_define_offload_policy 
+------------------------------
+ 
+(1 row)
+
+SELECT sum(local_bytes), sum(external_bytes), sum(external_bloat_bytes) FROM yezzey_offload_relation_status('regaostat');
+ sum |   sum   |   sum   
+-----+---------+---------
+   0 | 1001640 | 3004920
 (1 row)
 
 DROP TABLE regaostat;

--- a/expected/yezzey-stat.out
+++ b/expected/yezzey-stat.out
@@ -68,9 +68,9 @@ SELECT sum(local_bytes), sum(external_bytes) FROM yezzey_offload_relation_status
 
 ALTER EXTENSION yezzey UPDATE TO '1.8.7';
 SELECT sum(local_bytes), sum(external_bytes), sum(external_bloat_bytes) FROM yezzey_offload_relation_status('regaostat');
-   sum   |   sum   | sum 
----------+---------+-----
- 1001640 | 6009840 |   0
+   sum   |   sum   |   sum   
+---------+---------+---------
+ 1001640 | 6009840 | 6009840
 (1 row)
 
 DROP TABLE regaostat;

--- a/include/storage.h
+++ b/include/storage.h
@@ -52,7 +52,7 @@ EXTERNC int statRelationSpaceUsage(Relation aorel, int segno, int64 modcount,
                                    int64 logicalEof, size_t *local_bytes,
                                    size_t *local_commited_bytes,
                                    size_t *external_bytes,
-                                   size_t *external_bloat_bytes);
+                                   size_t *external_bloat_bytes, bool ext);
 
 EXTERNC int statRelationChunksSpaceUsage(Relation aorel, size_t *local_bytes,
                                          size_t *local_commited_bytes,

--- a/include/util.h
+++ b/include/util.h
@@ -29,7 +29,8 @@ extern const char *baseYezzeyPath;
 // to transfer segment file of given AO/AOCS relation,
 // with operation modcound $modcount$
 
-int64_t yezzey_virtual_relation_size(std::shared_ptr<IOadv> adv, int32_t segid);
+std::pair<int64_t, int64_t>
+yezzey_virtual_relation_size(std::shared_ptr<IOadv> adv, int32_t segid);
 
 int64_t yezzey_calc_virtual_relation_size(std::shared_ptr<IOadv> adv,
                                           ssize_t segindx, ssize_t modcount,

--- a/sql/yezzey-stat.sql
+++ b/sql/yezzey-stat.sql
@@ -27,6 +27,11 @@ SELECT sum(local_bytes), sum(external_bytes) FROM yezzey_offload_relation_status
 ALTER EXTENSION yezzey UPDATE TO '1.8.7';
 SELECT sum(local_bytes), sum(external_bytes), sum(external_bloat_bytes) FROM yezzey_offload_relation_status('regaostat');
 
+
+SELECT * FROM yezzey_define_offload_policy('regaostat');
+
+SELECT sum(local_bytes), sum(external_bytes), sum(external_bloat_bytes) FROM yezzey_offload_relation_status('regaostat');
+
 DROP TABLE regaostat;
 
 DROP EXTENSION yezzey;

--- a/src/storage.cpp
+++ b/src/storage.cpp
@@ -367,7 +367,8 @@ int offloadRelationSegment(Relation aorel, int segno, int64 modcount,
 
 #if 0
   if (/* support this feature */)
-    virtual_sz = yezzey_virtual_relation_size(ioadv, GpIdentity.segindex);
+    auto fb = yezzey_virtual_relation_size(ioadv, GpIdentity.segindex);
+    virtual_sz = fb.first;
 #endif
 
   if (virtual_sz == -1) {
@@ -426,8 +427,8 @@ Oid resolveTablespaceOidByName(std::string tablespacename) {
 int statRelationSpaceUsage(Relation aorel, int segno, int64 modcount,
                            int64 logicalEof, size_t *local_bytes,
                            size_t *local_committed_bytes,
-                           size_t *external_bytes,
-                           size_t *external_bloat_bytes) {
+                           size_t *external_bytes, size_t *external_bloat_bytes,
+                           bool ext) {
 
   auto rnode = aorel->rd_node;
 
@@ -459,12 +460,17 @@ int statRelationSpaceUsage(Relation aorel, int segno, int64 modcount,
       yproxy_socket);
   /* we dont need to interact with s3 while in recovery*/
   /* stat external storage usage */
-  auto virtual_sz = yezzey_virtual_relation_size(ioadv, GpIdentity.segindex);
+  auto fb = yezzey_virtual_relation_size(ioadv, GpIdentity.segindex);
+  auto virtual_sz = fb.first;
   if (virtual_sz == -1)
     elog(ERROR, "yezzey: failed to stat size of relation %s",
          RelationGetRelationName(aorel));
 
-  *external_bytes = virtual_sz;
+  if (ext)
+    *external_bytes = virtual_sz - fb.second;
+  else
+    *external_bytes = virtual_sz;
+  *external_bloat_bytes = fb.second;
 
   /* No local storage cache logic for now */
   auto local_path = getlocalpath(coords);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -7,6 +7,7 @@
 #include "util.h"
 
 #include <map>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -140,19 +141,31 @@ std::string make_yezzey_url(const std::string &prefix, int64_t modcount,
 }
 
 /* calc size of external files */
-int64_t yezzey_virtual_relation_size(std::shared_ptr<IOadv> adv,
-                                     int32_t segid) {
+std::pair<int64_t, int64_t>
+yezzey_virtual_relation_size(std::shared_ptr<IOadv> adv, int32_t segid) {
   try {
+    auto order =
+        YezzeyVirtualGetOrder(YezzeyFindAuxIndex(adv->reloid), adv->reloid,
+                              adv->coords_.filenode, adv->coords_.blkno);
+    std::set<std::string> used_chnk;
+
+    for (auto &o : order) {
+      used_chnk.insert(o.x_path);
+    }
+
     auto lister = YProxyLister(adv, segid);
     int64_t sz = 0;
+    int64_t szBloat = 0;
     auto chunks = lister.list_relation_chunks();
     for (auto chunk : chunks) {
       sz += chunk.chunkSize;
+      if (!used_chnk.count(chunk.chunkName))
+        szBloat += chunk.chunkSize;
     }
     /* external reader destruct */
-    return sz;
+    return {sz, szBloat};
   } catch (...) {
-    return -1;
+    return {-1, -1};
   }
 }
 

--- a/yezzey.c
+++ b/yezzey.c
@@ -1096,7 +1096,7 @@ static Datum yezzey_ofr_worker(PG_FUNCTION_ARGS, bool ext) {
 
       local_bytes += curr_local_bytes;
       external_bytes += curr_external_bytes;
-      external_bloat_bytes = curr_external_bloat_bytes;
+      external_bloat_bytes += curr_external_bloat_bytes;
       local_commited_bytes += curr_local_commited_bytes;
       /* segment if loaded */
     }

--- a/yezzey.c
+++ b/yezzey.c
@@ -733,8 +733,8 @@ static Datum yezzey_ofr_per_fs_worker(PG_FUNCTION_ARGS, bool ext) {
 
     if (statRelationSpaceUsage(aorel, segno, modcount, logicalEof,
                                &curr_local_bytes, &curr_local_commited_bytes,
-                               &curr_external_bytes,
-                               &curr_external_bloat_bytes) < 0) {
+                               &curr_external_bytes, &curr_external_bloat_bytes,
+                               ext) < 0) {
       elog(ERROR, "failed to stat segment %d usage", segno);
     }
 
@@ -770,8 +770,8 @@ static Datum yezzey_ofr_per_fs_worker(PG_FUNCTION_ARGS, bool ext) {
 
     if (statRelationSpaceUsage(aorel, pseudosegno, modcount, logicalEof,
                                &curr_local_bytes, &curr_local_commited_bytes,
-                               &curr_external_bytes,
-                               &curr_external_bloat_bytes) < 0) {
+                               &curr_external_bytes, &curr_external_bloat_bytes,
+                               ext) < 0) {
       elog(ERROR, "failed to stat segment block %d usage", pseudosegno);
     }
 
@@ -1090,7 +1090,7 @@ static Datum yezzey_ofr_worker(PG_FUNCTION_ARGS, bool ext) {
       if (statRelationSpaceUsage(aorel, segno, modcount, logicalEof,
                                  &curr_local_bytes, &curr_local_commited_bytes,
                                  &curr_external_bytes,
-                                 &curr_external_bloat_bytes) < 0) {
+                                 &curr_external_bloat_bytes, ext) < 0) {
         elog(ERROR, "yezzey: failed to stat segment %d usage", segno);
       }
 
@@ -1134,7 +1134,7 @@ static Datum yezzey_ofr_worker(PG_FUNCTION_ARGS, bool ext) {
         if (statRelationSpaceUsage(
                 aorel, pseudosegno, modcount, logicalEof, &curr_local_bytes,
                 &curr_local_commited_bytes, &curr_external_bytes,
-                &curr_external_bloat_bytes) < 0) {
+                &curr_external_bloat_bytes, ext) < 0) {
           elog(ERROR, "yezzey: failed to stat segment %d usage", segno);
         }
 


### PR DESCRIPTION
If called via modern stat API, external bytes will be reported excluding bloat bytes (garbage files)