### PR TITLE
Do not use tablespace map in open-gpdb tests

### DIFF
--- a/.github/workflows/yezzey-ci.yaml
+++ b/.github/workflows/yezzey-ci.yaml
@@ -557,20 +557,7 @@ jobs:
           set -eo pipefail
           set -x
 
-          #run yproxy in daemon mode
-          /usr/bin/yproxy -c /tmp/yproxy.yaml -ldebug > yproxy.log 2>&1 &
-
-          i=0
-          while (! [ -S /tmp/yproxy.sock ]) && [ $i -lt 20 ]; do sleep 1; i=$(($i+1)) ; done
-
-          if (! [ -S /tmp/yproxy.sock ]); then
-             echo "::error::Config yproxy failed"
-             exit 1
-          fi
-
-          chmod 777 /tmp/yproxy.sock
-
-          if ! time su - gpadmin -c "cd ${SRC_DIR}/gpcontrib/yezzey && source /opt/greenplum-db-6/greenplum_path.sh && source ../../gpAux/gpdemo/gpdemo-env.sh && make installcheck"; then
+          if ! time su - gpadmin -c "cd ${SRC_DIR} && ../yezzey/devops/scripts/launch_yproxy.sh && cd ${SRC_DIR}/gpcontrib/yezzey && source /opt/greenplum-db-6/greenplum_path.sh && source ../../gpAux/gpdemo/gpdemo-env.sh && make installcheck"; then
             echo "::error::Test yezzey failed"
             cat ${SRC_DIR}/gpcontrib/yezzey/regression.diffs
             exit 1

--- a/devops/build/docker/minio/README
+++ b/devops/build/docker/minio/README
@@ -1,0 +1,9 @@
+docker compose file to setup dev minio environment for yezzey
+
+to setup containers perform:
+
+1. Build
+   run: docker-compose -f ./docker-compose.yaml build
+
+2. Run Docker
+   run: docker-compose -f ./docker-compose.yaml up

--- a/devops/build/docker/minio/docker-compose.yaml
+++ b/devops/build/docker/minio/docker-compose.yaml
@@ -1,0 +1,29 @@
+services:
+  minio:
+    image: quay.io/minio/minio
+    command: server --console-address ":9001" /data
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    environment:
+      MINIO_ROOT_USER: some_key
+      MINIO_ROOT_PASSWORD: some_key
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    hostname: minio
+  
+  setup-minio:
+    image: quay.io/minio/mc
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: |
+      /bin/sh -c "
+      /usr/bin/mc alias set myminio http://minio:9000 some_key some_key
+      /usr/bin/mc mb myminio/gpyezzey
+      /usr/bin/mc mb myminio/gpyezzey2
+      /usr/bin/mc mb myminio/gpyezzey3
+      "

--- a/devops/config/yproxy.conf
+++ b/devops/config/yproxy.conf
@@ -1,6 +1,8 @@
 socket_path: "/tmp/yproxy.sock"
 interconnect_socket_path: "/tmp/ic.sock"
 log_level: debug
+debug_port: 2113
+debug_minutes: 120
 
 storage:
   access_key_id: "$AWS_ACCESS_KEY_ID"
@@ -12,8 +14,8 @@ storage:
   storage_type: "s3"
   tablespace_map:
     "pg_default": "gpyezzey"
-    "tab1": "gpyezzey2"
-    "tab2": "gpyezzey3"
+    "tab1": "gpyezzey"
+    "tab2": "gpyezzey"
 
 backup_storage:
   access_key_id: "$AWS_ACCESS_KEY_ID"

--- a/devops/scripts/launch_yproxy.sh
+++ b/devops/scripts/launch_yproxy.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+          set -eo pipefail
+          set -x
+
+          rm -rf /tmp/yproxy.sock
+          #run yproxy in daemon mode
+          /usr/bin/yproxy -c /tmp/yproxy.yaml -ldebug > yproxy.log 2>&1 &
+
+          i=0
+          while (! [ -S /tmp/yproxy.sock ]) && [ $i -lt 20 ]; do sleep 1; i=$(($i+1)) ; done
+
+          if (! [ -S /tmp/yproxy.sock ]); then
+             echo "::error::Config yproxy failed"
+             exit 1
+          fi
+
+          chmod 777 /tmp/yproxy.sock


### PR DESCRIPTION
We use credentialsMap for store credentials in yproxy.

But static credentials are set only for default tablespace - `gpyezzey`. Others two use default credentials provider. Default credentials provider is not set (in a Docker) correctly, so queries hang forever and we could see a numerous messages `resigning` in yproxy.log

yproxy process also waits for syn_sent answer for non-existence default credentials host

```
yproxy  53531 gpadmin   13u     IPv4          264361572      0t0       TCP cdw:45054-><ip>:80 (SYN_SENT)
yproxy  53531 gpadmin   14u     IPv4          264345463      0t0       TCP cdw:43130-><ip>:80 (SYN_SENT)
yproxy  53531 gpadmin   15u     IPv4          264410117      0t0       TCP cdw:58594-><ip>:80 (SYN_SENT)
yproxy  53531 gpadmin   16u     IPv4          264361571      0t0       TCP cdw:58602-><ip>:80 (SYN_SENT)
yproxy  53531 gpadmin   17u     IPv4          264378210      0t0       TCP cdw:38558-><ip>:80 (SYN_SENT)
yproxy  53531 gpadmin   18u     IPv4          264361581      0t0       TCP cdw:38560-><ip>:80 (SYN_SENT)
```
