### PR TITLE
Fix file size getting

### DIFF
--- a/src/proxy.cpp
+++ b/src/proxy.cpp
@@ -543,6 +543,6 @@ EXTERNC off_t yezzey_FileSize(File file) {
     return YVirtFD_cache[file].handler->total_size();
   }
 
-  return FileSize(file);
+  return FileSize(actual_fd);
 }
 #endif


### PR DESCRIPTION
It is necessary to pass Greenplum internal file descritor to FileSize, but
yezzey specific one was passed