### PR TITLE
Fix buffer overflow in getYezzeyExternalStoragePathByCoords

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -93,7 +93,8 @@ void getYezzeyExternalStoragePathByCoords(const char *nspname,
   auto coords = relnodeCoord(spcNode, dbNode, relNode, segblockno);
   auto prefix = getYezzeyRelationUrl_internal(nspname, relname, coords, segid);
 
-  *dest = (char *)palloc(sizeof(char) * prefix.size());
+  /* +1 for the terminating null byte that strcpy writes */
+  *dest = (char *)palloc(sizeof(char) * (prefix.size() + 1));
   strcpy(*dest, prefix.c_str());
   return;
 }


### PR DESCRIPTION
palloc allocated prefix.size() bytes, `If the length of src is less than n, strncpy() writes additional null bytes to dest to ensure that a total of n bytes are written.`, see https://linux.die.net/man/3/strcpy. Allocate prefix.size() + 1 to avoid a one-byte heap overflow.