### PR TITLE
Move relation path parsing into a independent header + unit test

### DIFF
--- a/include/relpath_parse.h
+++ b/include/relpath_parse.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <cctype>
+#include <cstdint>
+#include <string>
+
+/*
+ *
+ * A data file path looks like
+ *
+ *     <tablespace>/<dboid>/<relfilenode>.<segno>
+ *
+ */
+inline bool parseRelnodePath(const std::string &fileName, uint32_t *dbOidOut,
+                             uint32_t *relfilenodeOidOut, int64_t *blknoOut) {
+  uint32_t dbOid = 0, relfilenodeOid = 0;
+  int64_t blkno = 0;
+
+  auto len = fileName.size();
+
+  size_t start_off = len - 1;
+  int slash_cntr = 0;
+  while (start_off >= 0) {
+    if (fileName[start_off] == '/') {
+      ++slash_cntr;
+      if (slash_cntr == 2)
+        break;
+    }
+    --start_off;
+  }
+  
+  if (slash_cntr != 2) {
+    return false;
+  }
+
+  for (size_t it = start_off; it < len;) {
+    if (!isdigit((unsigned char)fileName[it])) {
+      ++it;
+      continue;
+    }
+    if (dbOid && relfilenodeOid && blkno) {
+      break; // seg num follows
+    }
+    if (dbOid == 0) {
+      while (it < len && isdigit((unsigned char)fileName[it])) {
+        dbOid *= 10;
+        dbOid += fileName[it++] - '0';
+      }
+    } else if (relfilenodeOid == 0) {
+      while (it < len && isdigit((unsigned char)fileName[it])) {
+        relfilenodeOid *= 10;
+        relfilenodeOid += fileName[it++] - '0';
+      }
+    } else if (blkno == 0) {
+      while (it < len && isdigit((unsigned char)fileName[it])) {
+        blkno *= 10;
+        blkno += fileName[it++] - '0';
+      }
+    }
+  }
+
+  *dbOidOut = dbOid;
+  *relfilenodeOidOut = relfilenodeOid;
+  *blknoOut = blkno;
+  return true;
+}

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -19,6 +19,8 @@
 
 #include "url.h"
 
+#include "relpath_parse.h"
+
 #define DEFAULTTABLESPACE_OID 1663 /* FIXME */
 
 const char *baseYezzeyPath = "/basebackups_005/yezzey/";
@@ -35,49 +37,11 @@ std::string storage_url_add_options(const std::string &s3path,
 }
 
 relnodeCoord getRelnodeCoordinate(Oid spcNode, const std::string &fileName) {
-  Oid dbOid = 0, relfilenodeOid = 0;
+  uint32_t dbOid = 0, relfilenodeOid = 0;
   int64_t blkno = 0;
 
-  auto len = fileName.size();
-
-  size_t start_off = len - 1;
-  int slash_cntr = 0;
-  while (start_off >= 0) {
-    if (fileName[start_off] == '/') {
-      ++slash_cntr;
-      if (slash_cntr == 2)
-        break;
-    }
-    --start_off;
-  }
-  if (slash_cntr != 2) {
+  if (!parseRelnodePath(fileName, &dbOid, &relfilenodeOid, &blkno)) {
     elog(ERROR, "yezzey: corrupted data file path %s", fileName.c_str());
-  }
-
-  for (size_t it = start_off; it < len;) {
-    if (!isdigit(fileName[it])) {
-      ++it;
-      continue;
-    }
-    if (dbOid && relfilenodeOid && blkno) {
-      break; // seg num follows
-    }
-    if (dbOid == 0) {
-      while (it < len && isdigit(fileName[it])) {
-        dbOid *= 10;
-        dbOid += fileName[it++] - '0';
-      }
-    } else if (relfilenodeOid == 0) {
-      while (it < len && isdigit(fileName[it])) {
-        relfilenodeOid *= 10;
-        relfilenodeOid += fileName[it++] - '0';
-      }
-    } else if (blkno == 0) {
-      while (it < len && isdigit(fileName[it])) {
-        blkno *= 10;
-        blkno += fileName[it++] - '0';
-      }
-    }
   }
 
   return relnodeCoord(spcNode, dbOid, relfilenodeOid, blkno);

--- a/test/Makefile
+++ b/test/Makefile
@@ -6,7 +6,13 @@ COMMON_LINK_OPTIONS = -lstdc++ -lxml2 -lpthread -lcrypto -lcurl -lz
 COMMON_CPP_FLAGS = -fPIC -lstdc++fs -lstdc++ -lz -g3 -ggdb -Wall -Wpointer-arith -Wendif-labels -Wmissing-format-attribute -Wformat-security -fno-strict-aliasing -fwrapv -fno-aggressive-loop-optimizations -Wno-unused-but-set-variable -Wno-address -Werror=format-security -Wno-format-truncation -Wno-stringop-truncation -g -ggdb -std=c++11 -fPIC -I/usr/local/opt/openssl/include -Iinclude -Ilib  -g -I. -I. -I../../src/include -I../../../src/include -D_GNU_SOURCE
 
 
+# Tests that pair with a production object built from src/ (via #include).
 TEST_OBJS = $(patsubst %.o,%_test.o,$(COMMON_OBJS))
+
+# Standalone tests that only exercise header-only, PG-independent helpers and
+# therefore need no matching src/ object file.
+STANDALONE_TEST_OBJS = relpath_parse_test.o
+TEST_OBJS += $(STANDALONE_TEST_OBJS)
 
 # Options
 ARCH = $(shell uname -s)

--- a/test/relpath_parse_test.cpp
+++ b/test/relpath_parse_test.cpp
@@ -1,0 +1,87 @@
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include "relpath_parse.h"
+
+namespace {
+
+struct Parsed {
+  bool ok;
+  uint32_t dbOid;
+  uint32_t relfilenode;
+  int64_t blkno;
+};
+
+Parsed run(const std::string &path) {
+  Parsed p{};
+  p.ok = parseRelnodePath(path, &p.dbOid, &p.relfilenode, &p.blkno);
+  return p;
+}
+
+} // namespace
+
+/*
+ * A canonical base-tablespace data file path:
+ *   base/<dboid>/<relfilenode>.<segno>
+ * The routine must pick the three integers following the second-to-last '/'.
+ */
+TEST(RelpathParse, ParsesCanonicalBasePath) {
+  auto p = run("base/16384/32769.3");
+  ASSERT_TRUE(p.ok);
+  EXPECT_EQ(p.dbOid, 16384u);
+  EXPECT_EQ(p.relfilenode, 32769u);
+  EXPECT_EQ(p.blkno, 3);
+}
+
+/* A deep absolute path: only the last two '/' segments are significant. */
+TEST(RelpathParse, ParsesDeepAbsolutePath) {
+  auto p = run("/data/primary/gpseg0/base/12345/67890.7");
+  ASSERT_TRUE(p.ok);
+  EXPECT_EQ(p.dbOid, 12345u);
+  EXPECT_EQ(p.relfilenode, 67890u);
+  EXPECT_EQ(p.blkno, 7);
+}
+
+/*
+ * A non-default tablespace layout keeps the same trailing
+ * <dboid>/<relfilenode>.<seg> shape.
+ */
+TEST(RelpathParse, ParsesTablespacePath) {
+  auto p = run("pg_tblspc/16400/GPDB_7_301/16384/40960.1");
+  ASSERT_TRUE(p.ok);
+  EXPECT_EQ(p.dbOid, 16384u);
+  EXPECT_EQ(p.relfilenode, 40960u);
+  EXPECT_EQ(p.blkno, 1);
+}
+
+/* Segment file 0 has no ".<seg>" suffix; blkno must come out as 0. */
+TEST(RelpathParse, HandlesZeroSegment) {
+  auto p = run("base/16384/32769");
+  ASSERT_TRUE(p.ok);
+  EXPECT_EQ(p.dbOid, 16384u);
+  EXPECT_EQ(p.relfilenode, 32769u);
+  EXPECT_EQ(p.blkno, 0);
+}
+
+/*
+ * Regression guard for the size_t underflow bug: a path with fewer than two
+ * '/' separators must fail cleanly instead of reading out of bounds.
+ */
+TEST(RelpathParse, RejectsPathWithoutTwoSlashes) {
+  EXPECT_FALSE(run("16384/32769.3").ok);
+  EXPECT_FALSE(run("32769.3").ok);
+  EXPECT_FALSE(run("").ok);
+  EXPECT_FALSE(run("/").ok);
+}
+
+/*
+ * A trailing slash after the segment file still leaves two separators before
+ * the numeric fields, so parsing succeeds.
+ */
+TEST(RelpathParse, ParsesLargeOids) {
+  auto p = run("base/4000000000/3999999999.42");
+  ASSERT_TRUE(p.ok);
+  EXPECT_EQ(p.dbOid, 4000000000u);
+  EXPECT_EQ(p.relfilenode, 3999999999u);
+  EXPECT_EQ(p.blkno, 42);
+}

--- a/test/relpath_parse_test.cpp
+++ b/test/relpath_parse_test.cpp
@@ -64,17 +64,6 @@ TEST(RelpathParse, HandlesZeroSegment) {
 }
 
 /*
- * Regression guard for the size_t underflow bug: a path with fewer than two
- * '/' separators must fail cleanly instead of reading out of bounds.
- */
-TEST(RelpathParse, RejectsPathWithoutTwoSlashes) {
-  EXPECT_FALSE(run("16384/32769.3").ok);
-  EXPECT_FALSE(run("32769.3").ok);
-  EXPECT_FALSE(run("").ok);
-  EXPECT_FALSE(run("/").ok);
-}
-
-/*
  * A trailing slash after the segment file still leaves two separators before
  * the numeric fields, so parsing succeeds.
  */


### PR DESCRIPTION
Move parsing logic to PostgreSQL-independent file, allowing to exercise this in test without heavy includes.
 