### PR TITLE
Manage yproxy connection lifetime with a shared RAII scope guard

### DIFF
--- a/include/scope_guard.h
+++ b/include/scope_guard.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <utility>
+
+template <typename F> class ScopeGuard {
+public:
+  explicit ScopeGuard(F fn) : fn_(std::move(fn)), active_(true) {}
+  ScopeGuard(ScopeGuard &&other) noexcept
+      : fn_(std::move(other.fn_)), active_(other.active_) {
+    other.active_ = false;
+  }
+  ~ScopeGuard() {
+    if (active_) {
+      fn_();
+    }
+  }
+  ScopeGuard(const ScopeGuard &) = delete;
+  ScopeGuard &operator=(const ScopeGuard &) = delete;
+  ScopeGuard &operator=(ScopeGuard &&) = delete;
+
+  /* cancel the pending action (e.g. on the success path) */
+  void dismiss() { active_ = false; }
+
+private:
+  F fn_;
+  bool active_;
+};
+
+template <typename F> ScopeGuard<F> makeScopeGuard(F fn) {
+  return ScopeGuard<F>(std::move(fn));
+}

--- a/src/yproxy_deleter.cpp
+++ b/src/yproxy_deleter.cpp
@@ -1,4 +1,5 @@
 #include "yproxy_deleter.h"
+#include "scope_guard.h"
 
 YProxyDeleter::YProxyDeleter(std::shared_ptr<IOadv> adv, ssize_t segindx,
                              bool confirm)
@@ -16,10 +17,10 @@ YProxyDeleter::YProxyDeleter(std::shared_ptr<IOadv> adv)
 YProxyDeleter::~YProxyDeleter() { close(); }
 
 bool YProxyDeleter::deleteChunk(const std::string &chunkName) {
+  auto connGuard = makeScopeGuard([this] { this->close(); });
+
   if (client_fd_ == -1) {
     if (prepareYproxyConnection() == -1) {
-      // Throw here?
-      close();
       return false;
     }
   }
@@ -28,15 +29,14 @@ bool YProxyDeleter::deleteChunk(const std::string &chunkName) {
   auto msg = ConstructDeleteRequest(chunkName);
 
   if (commonWriteFull(client_fd_, msg) == -1) {
-    close();
     return false;
   }
   // wait for responce
   if (commonReadRFQResponce(client_fd_) != 0) {
-    close();
     return false;
   }
 
+  connGuard.dismiss();
   return true;
 }
 

--- a/src/yproxy_deleter_v2.cpp
+++ b/src/yproxy_deleter_v2.cpp
@@ -1,4 +1,5 @@
 #include "yproxy_deleter_v2.h"
+#include "scope_guard.h"
 
 YProxyDeleterV2::YProxyDeleterV2(std::shared_ptr<IOadv> adv, ssize_t segindx,
                                  std::string dbname, bool crazy_drop_)
@@ -12,10 +13,10 @@ YProxyDeleterV2::YProxyDeleterV2(std::shared_ptr<IOadv> adv, ssize_t segindx,
 YProxyDeleterV2::~YProxyDeleterV2() { close(); }
 
 bool YProxyDeleterV2::Delete(const std::string &chunkName) {
+  auto connGuard = makeScopeGuard([this] { this->close(); });
+
   if (client_fd_ == -1) {
     if (prepareYproxyConnection() == -1) {
-      // Throw here?
-      close();
       return false;
     }
   }
@@ -24,23 +25,22 @@ bool YProxyDeleterV2::Delete(const std::string &chunkName) {
   auto msg = ConstructDeleteRequest(chunkName);
 
   if (commonWriteFull(client_fd_, msg) == -1) {
-    close();
     return false;
   }
   // wait for responce
   if (commonReadRFQResponce(client_fd_) != 0) {
-    close();
     return false;
   }
 
+  connGuard.dismiss();
   return true;
 }
 
 bool YProxyDeleterV2::Collect(const std::string &chunkName) {
+  auto connGuard = makeScopeGuard([this] { this->close(); });
+
   if (client_fd_ == -1) {
     if (prepareYproxyConnection() == -1) {
-      // Throw here?
-      close();
       return false;
     }
   }
@@ -49,16 +49,15 @@ bool YProxyDeleterV2::Collect(const std::string &chunkName) {
   auto msg = ConstructCollectRequest(chunkName);
 
   if (commonWriteFull(client_fd_, msg) == -1) {
-    close();
     return false;
   }
 
   // wait for responce
   if (commonReadRFQResponce(client_fd_) != 0) {
-    close();
     return false;
   }
 
+  connGuard.dismiss();
   return true;
 }
 

--- a/src/yproxy_lister.cpp
+++ b/src/yproxy_lister.cpp
@@ -1,40 +1,11 @@
 #include "yproxy_lister.h"
+#include "scope_guard.h"
 #include "url.h"
 
-#include <utility>
-
 /*
+ *
  *  Yproxy Lister
  */
-
-namespace {
-
-template <typename F> class ScopeGuard {
-public:
-  explicit ScopeGuard(F fn) : fn_(std::move(fn)), active_(true) {}
-  ScopeGuard(ScopeGuard &&other) noexcept
-      : fn_(std::move(other.fn_)), active_(other.active_) {
-    other.active_ = false;
-  }
-  ~ScopeGuard() {
-    if (active_) {
-      fn_();
-    }
-  }
-  ScopeGuard(const ScopeGuard &) = delete;
-  ScopeGuard &operator=(const ScopeGuard &) = delete;
-  ScopeGuard &operator=(ScopeGuard &&) = delete;
-
-private:
-  F fn_;
-  bool active_;
-};
-
-template <typename F> ScopeGuard<F> makeScopeGuard(F fn) {
-  return ScopeGuard<F>(std::move(fn));
-}
-
-} // namespace
 
 YProxyLister::YProxyLister(std::shared_ptr<IOadv> adv, ssize_t segindx)
     : YProxyConnector(adv, segindx) {}


### PR DESCRIPTION
Also move auxuliar class (ScopeGuard) to its own file.