### PR TITLE
Use errcodes for user-facing errors

### DIFF
--- a/expected/yezzey-alter-ts.out
+++ b/expected/yezzey-alter-ts.out
@@ -10,7 +10,7 @@ SELECT yezzey_define_offload_policy('regao_y_ats');
 
 --should fail
 ALTER TABLE regao_y_ats SET TABLESPACE pg_default;
-ERROR:  altering YEZZEY relation TABLESPACE is forbidden (yezzey.c:1377)
+ERROR:  altering YEZZEY relation TABLESPACE is forbidden
 DROP TABLE regao_y_ats;
 DROP EXTENSION yezzey;
 DROP TABLESPACE tab1;

--- a/expected/yezzey-alter-ts_cbdb.out
+++ b/expected/yezzey-alter-ts_cbdb.out
@@ -10,7 +10,7 @@ SELECT yezzey_define_offload_policy('regao_y_ats');
 
 --should fail
 ALTER TABLE regao_y_ats SET TABLESPACE pg_default;
-ERROR:  altering YEZZEY relation TABLESPACE is forbidden (yezzey.c:1349)
+ERROR:  altering YEZZEY relation TABLESPACE is forbidden
 DROP TABLE regao_y_ats;
 DROP EXTENSION yezzey;
 DROP TABLESPACE tab1;

--- a/yezzey.c
+++ b/yezzey.c
@@ -1374,7 +1374,9 @@ static void yezzey_ProcessUtility_hook(Node *parsetree, const char *queryString,
       foreach (lcmd, stmt->cmds) {
         AlterTableCmd *cmd = (AlterTableCmd *)lfirst(lcmd);
         if (cmd->subtype == AT_SetTableSpace) {
-          elog(ERROR, "altering YEZZEY relation TABLESPACE is forbidden");
+          ereport(ERROR,
+                  (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+                   errmsg("altering YEZZEY relation TABLESPACE is forbidden")));
         }
         newTOASTTableSpace = YezzeyGetRelationOriginTablespaceOid(
             get_namespace_name(rel->rd_rel->relnamespace),


### PR DESCRIPTION
This stabilizes test output