### PR TITLE
Fix polymorphic overrides in yproxy reader

### DIFF
--- a/include/yproxy_reader.h
+++ b/include/yproxy_reader.h
@@ -9,6 +9,7 @@
 /* reader using yproxy */
 class YProxyReader : YProxyConnector {
 public:
+  using YProxyConnector::prepareYproxyConnection;
   friend class ExternalWriter;
   explicit YProxyReader(std::shared_ptr<IOadv> adv, ssize_t segindx,
                         std::vector<ChunkInfo> order);


### PR DESCRIPTION
```
In file included from ./include/yproxy_reader.h:6,
                 from src/yproxy_reader.cpp:1:
./include/yproxy_connector.h:17:15: warning: ‘virtual int YProxyConnector::prepareYproxyConnection()’ was hidden [-Woverloaded-virtual=]
   17 |   virtual int prepareYproxyConnection();
      |               ^~~~~~~~~~~~~~~~~~~~~~~
./include/yproxy_reader.h:27:15: note:   by ‘virtual int YProxyReader::prepareYproxyConnection(const ChunkInfo&, size_t)’
   27 |   virtual int prepareYproxyConnection(const ChunkInfo &ci, size_t start_off);
      |               ^~~~~~~~~~~~~~~~~~~~~~~
In file included from ./include/yproxy_deleter.h:3,
                 from ./include/yproxy.h:3,
                 from ./include/io.h:9,
                 from ./include/util.h:21,
                 from src/util.cpp:7:
./include/yproxy_connector.h:17:15: warning: ‘virtual int YProxyConnector::prepareYproxyConnection()’ was hidden [-Woverloaded-virtual=]
   17 |   virtual int prepareYproxyConnection();
      |               ^~~~~~~~~~~~~~~~~~~~~~~


```